### PR TITLE
Addded support for a LoginException in TorrentSearchProvider.

### DIFF
--- a/src/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
+++ b/src/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
@@ -25,6 +25,8 @@ import java.security.InvalidParameterException;
 import java.text.*;
 import java.util.*;
 
+import javax.security.auth.login.LoginException;
+
 import org.apache.http.*;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
@@ -75,7 +77,7 @@ public class AsiaTorrentsAdapter implements ISearchAdapter {
 		HttpResponse loginResult = httpclient.execute(loginPost);
 		if (loginResult.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
 			// Failed to sign in
-			throw new Exception("Login failure for AsiaTorrents with user " + username);
+			throw new LoginException("Login failure for AsiaTorrents with user " + username);
 		}
 
 		return httpclient;

--- a/src/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
+++ b/src/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
@@ -30,6 +30,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
+import javax.security.auth.login.LoginException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -65,8 +67,8 @@ public class BitHdtvAdapter implements ISearchAdapter {
 
 	private DefaultHttpClient prepareRequest(Context context) throws Exception {
 
-		String username = SettingsHelper.getSiteUser(context, TorrentSite.IpTorrents);
-		String password = SettingsHelper.getSitePass(context, TorrentSite.IpTorrents);
+		String username = SettingsHelper.getSiteUser(context, TorrentSite.BitHdtv);
+		String password = SettingsHelper.getSitePass(context, TorrentSite.BitHdtv);
 		if (username == null || password == null) {
 			throw new InvalidParameterException(
 					"No username or password was provided, while this is required for this private site.");
@@ -85,7 +87,7 @@ public class BitHdtvAdapter implements ISearchAdapter {
 		HttpResponse loginResult = httpclient.execute(loginPost);
 		if (loginResult.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
 			// Failed to sign in
-			throw new Exception("Login failure for IPTorrents with user " + username);
+			throw new LoginException("Login failure for BitHdTv with user " + username);
 		}
 		
 		return httpclient;

--- a/src/org/transdroid/search/IpTorrents/IpTorrentsAdapter.java
+++ b/src/org/transdroid/search/IpTorrents/IpTorrentsAdapter.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.security.auth.login.LoginException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -80,7 +82,7 @@ public class IpTorrentsAdapter implements ISearchAdapter {
 		HttpResponse loginResult = httpclient.execute(loginPost);
 		if (loginResult.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
 			// Failed to sign in
-			throw new Exception("Login failure for IPTorrents with user " + username);
+			throw new LoginException("Login failure for IPTorrents with user " + username);
 		}
 
 		return httpclient;

--- a/src/org/transdroid/search/hdbitsorg/HdBitsOrgAdapter.java
+++ b/src/org/transdroid/search/hdbitsorg/HdBitsOrgAdapter.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.security.auth.login.LoginException;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -220,10 +222,8 @@ public class HdBitsOrgAdapter implements ISearchAdapter {
         // if we don't have the correct cookies, login failed. notify user with a toast and toss an exception.
         success = uid && pass && hash;
         if (!success) {
-            // this toast really shouldn't be implemented here, but main app doesn't currently notify user
-            // of a login failure, it simply says no search results.
-            backgroundToast(R.string.login_failure);
-            throw new Exception("Failed to log into hdbits.org as '" + username + "'. Did not receive expected login cookies!");            
+        	Log.e(LOG_TAG, "Failed to log into hdbits.org as '" + username + "'. Did not receive expected login cookies!");
+            throw new LoginException("Failed to log into hdbits.org as '" + username + "'. Did not receive expected login cookies!");            
         }
         
         Log.d(LOG_TAG, "Successfully logged in to hdbits.org.");
@@ -280,25 +280,5 @@ public class HdBitsOrgAdapter implements ISearchAdapter {
         
         Log.d(LOG_TAG, "Found " + matchCount + " matches and successfully parsed " + (matchCount - errorCount) + " of those matches.");
         return results;
-    }
-    
-    // =========================================================
-    // UTILITY METHODS
-    // =========================================================
-    
-    private void backgroundToast(final int resourceId) {
-        new Thread() {
-            @Override public void run() {                    
-                Looper.prepare();
-                Handler handler = new Handler();
-                handler.post(new Runnable() {
-                    @Override public void run() {
-                        Toast.makeText(context, context.getString(resourceId), Toast.LENGTH_LONG).show();
-                    }
-                });                
-                Looper.loop();
-                Looper.myLooper().quit();
-            }
-        }.start();
     }
 }


### PR DESCRIPTION
As we discussed in Issue #8, these changes move the login error Toast from the hdbits.org adapter to the TorrentSearchProvider. I have also modified existing private tracker adapters to throw a LoginException on login failure.
