### PR TITLE
Add New Auth Type:  Cookies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
 }
 dependencies {
     compile files('libs/android-json-rpc-0.3.4.jar')
+    compile 'org.jsoup:jsoup:1.11.2'
 
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile "com.google.truth:truth:0.30"

--- a/app/src/androidTest/java/org/transdroid/search/TorrentSiteTest.java
+++ b/app/src/androidTest/java/org/transdroid/search/TorrentSiteTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
+import static org.transdroid.search.ISearchAdapter.AuthType.NONE;
 
 @RunWith(AndroidJUnit4.class)
 public class TorrentSiteTest {
@@ -128,7 +129,7 @@ public class TorrentSiteTest {
 
 	private void searchSite(TorrentSite torrentSite) throws Exception {
 		// Set test user and password
-		if (torrentSite.getAdapter().isPrivateSite()) {
+		if (torrentSite.getAdapter().getAuthType() != NONE) {
 			String user = getResourceString(torrentSite.name() + "_user");
 			String pass = getResourceString(torrentSite.name() + "_pass");
 			String token = getResourceString(torrentSite.name() + "_token");

--- a/app/src/main/java/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
@@ -248,9 +248,12 @@ public class AsiaTorrentsAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/AsiaTorrents/AsiaTorrentsAdapter.java
@@ -243,11 +243,6 @@ public class AsiaTorrentsAdapter implements ISearchAdapter {
 		return "AsiaTorrents";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/BTN/BTNAdapter.java
+++ b/app/src/main/java/org/transdroid/search/BTN/BTNAdapter.java
@@ -170,8 +170,12 @@ public class BTNAdapter implements ISearchAdapter {
 	}
 
 	@Override
-	public boolean usesToken() {
-		return true;
+	public AuthType getAuthType() {
+		return AuthType.TOKEN;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 	class TorrentSeedsComparator implements Comparator<SearchResult> {

--- a/app/src/main/java/org/transdroid/search/BTN/BTNAdapter.java
+++ b/app/src/main/java/org/transdroid/search/BTN/BTNAdapter.java
@@ -165,11 +165,6 @@ public class BTNAdapter implements ISearchAdapter {
 	}
 
 	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
-	@Override
 	public AuthType getAuthType() {
 		return AuthType.TOKEN;
 	}

--- a/app/src/main/java/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
+++ b/app/src/main/java/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
@@ -219,11 +219,6 @@ public class BitHdtvAdapter implements ISearchAdapter {
 		return "BIT-HDTV";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
+++ b/app/src/main/java/org/transdroid/search/BitHdtv/BitHdtvAdapter.java
@@ -224,9 +224,12 @@ public class BitHdtvAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/Danishbits/DanishbitsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/Danishbits/DanishbitsAdapter.java
@@ -230,9 +230,12 @@ public class DanishbitsAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/Danishbits/DanishbitsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/Danishbits/DanishbitsAdapter.java
@@ -225,11 +225,6 @@ public class DanishbitsAdapter implements ISearchAdapter {
 		return "Danishbits";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/Demonoid/DemonoidAdapter.java
+++ b/app/src/main/java/org/transdroid/search/Demonoid/DemonoidAdapter.java
@@ -204,13 +204,8 @@ public class DemonoidAdapter implements ISearchAdapter {
 		return new SearchResult(name, link, details, size, date, seeders, leechers);
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/HoundDawgs/HoundDawgsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/HoundDawgs/HoundDawgsAdapter.java
@@ -223,11 +223,6 @@ public class HoundDawgsAdapter implements ISearchAdapter {
 		return "HoundDawgs";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/HoundDawgs/HoundDawgsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/HoundDawgs/HoundDawgsAdapter.java
@@ -228,9 +228,12 @@ public class HoundDawgsAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/ISearchAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ISearchAdapter.java
@@ -29,6 +29,11 @@ import android.content.SharedPreferences;
  * @author Eric Kok
  */
 public interface ISearchAdapter {
+	enum AuthType {
+		TOKEN,
+		USERNAME,
+		COOKIES,
+	}
 
 	/**
 	 * Implementing search providers should synchronously perform the search for torrents matching the given query
@@ -67,7 +72,10 @@ public interface ISearchAdapter {
 	 * Implementing search providers should return whether the site uses a token authentication system.
 	 * @return True is a session token is used in lieu of a username/password login combination
 	 */
-	boolean usesToken();
+	AuthType getAuthType();
+
+
+	String[] getRequiredCookies();
 
 	/**
 	 * Implement search providers should set up an HTTP request for the specified torrent file uri and, possibly after

--- a/app/src/main/java/org/transdroid/search/ISearchAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ISearchAdapter.java
@@ -30,6 +30,7 @@ import android.content.SharedPreferences;
  */
 public interface ISearchAdapter {
 	enum AuthType {
+		NONE,
 		TOKEN,
 		USERNAME,
 		COOKIES,
@@ -60,13 +61,6 @@ public interface ISearchAdapter {
 	 * @return The name of the torrent site
 	 */
 	String getSiteName();
-
-	/**
-	 * Implementing search providers should return whether this is a private site, that is, whether this site requires
-	 * user credentials before it can be searched.
-	 * @return True if this is an adapter to a private site, false otherwise.
-	 */
-	boolean isPrivateSite();
 
 	/**
 	 * Implementing search providers should return whether the site uses a token authentication system.

--- a/app/src/main/java/org/transdroid/search/ISearchAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ISearchAdapter.java
@@ -63,12 +63,17 @@ public interface ISearchAdapter {
 	String getSiteName();
 
 	/**
-	 * Implementing search providers should return whether the site uses a token authentication system.
-	 * @return True is a session token is used in lieu of a username/password login combination
+	 * Implementing search provider should return what authentication system it uses.
+	 * @return Type of authentication or NONE if public site.
 	 */
 	AuthType getAuthType();
 
 
+	/**
+	 * Providers using a Cookie authentication system should return an array of the cookie names
+	 * it requires.
+	 * @return An array of cookie names or null if not a using Cookie authentication.
+	 */
 	String[] getRequiredCookies();
 
 	/**

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/ExtraTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/ExtraTorrentAdapter.java
@@ -29,7 +29,7 @@ import org.transdroid.util.FileSizeConverter;
 
 /**
  * Search adapter for the ExtraTorrent torrent site (based on custom search RSS feeds)
- * 
+ *
  * @author Eric Kok
  */
 public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
@@ -37,12 +37,12 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 	protected SearchResult fromRssItemToSearchResult(Item item) {
 		ExtraTorrentsItem theItem = (ExtraTorrentsItem) item;
 		return new SearchResult(
-				item.getTitle(), 
+				item.getTitle(),
 				item.getEnclosureUrl(),
 				item.getLink(),
-				theItem.getSize() == -1? "": FileSizeConverter.getSize(theItem.getSize()),  
+				theItem.getSize() == -1? "": FileSizeConverter.getSize(theItem.getSize()),
 				item.getPubdate(),
-				theItem.getSeeders(), 
+				theItem.getSeeders(),
 				theItem.getLeechers());
 	}
 
@@ -61,7 +61,7 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 	protected RssParser getRssParser(String url) {
 		return new ExtraTorrentsRssParser(url);
 	}
-	
+
 	/**
 	 * Custom Item with addition size, seeders and leechers data properties
 	 */
@@ -76,7 +76,7 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 		public int getSeeders() { return seeders; }
 		public int getLeechers() { return leechers; }
 	}
-	
+
 	/**
 	 * Custom parser to parse the additional size, seeders and leechers data properties
 	 */
@@ -85,7 +85,7 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 		public ExtraTorrentsRssParser(String url) {
 			super(url);
 		}
-		
+
 		public Item createNewItem() {
 			return new ExtraTorrentsItem();
 		}
@@ -126,9 +126,12 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/ExtraTorrentAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/ExtraTorrentAdapter.java
@@ -121,13 +121,8 @@ public class ExtraTorrentAdapter extends RssFeedSearchAdapter {
 		return "ExtraTorrent";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/LimeTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/LimeTorrentsAdapter.java
@@ -30,7 +30,7 @@ import org.transdroid.util.FileSizeConverter;
 /**
  * Search adapter for the LimeTorrents torrent site (based on custom search RSS feeds)
  * This adapter does not support sorting.
- * 
+ *
  * @author Eric Kok
  */
 public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
@@ -42,9 +42,9 @@ public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
 				item.getTitle(),
 				item.getEnclosureUrl(),
 				item.getLink(),
-				FileSizeConverter.getSize(theItem.size), 
-				item.getPubdate(), 
-				theItem.seeders, 
+				FileSizeConverter.getSize(theItem.size),
+				item.getPubdate(),
+				theItem.seeders,
 				theItem.leechers);
 	}
 
@@ -70,7 +70,7 @@ public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
 		public int seeders, leechers;
 		public long size;
 	}
-	
+
 	/**
 	 * Custom parser to parse the additional comments data property
 	 */
@@ -79,7 +79,7 @@ public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
 		public LimeTorrentsParser(String url) {
 			super(url);
 		}
-		
+
 		public Item createNewItem() {
 			return new LimeTorrentsItem();
 		}
@@ -123,9 +123,12 @@ public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/LimeTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/LimeTorrentsAdapter.java
@@ -118,13 +118,8 @@ public class LimeTorrentsAdapter extends RssFeedSearchAdapter {
 		return "LimeTorrents";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/PretomeAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/PretomeAdapter.java
@@ -115,11 +115,6 @@ public class PretomeAdapter extends RssFeedSearchAdapter {
 		return "Pretome";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.TOKEN;
 	}

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/PretomeAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/PretomeAdapter.java
@@ -120,9 +120,12 @@ public class PretomeAdapter extends RssFeedSearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return true;
+	public AuthType getAuthType() {
+		return AuthType.TOKEN;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 	@Override

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/SkyTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/SkyTorrentsAdapter.java
@@ -166,9 +166,12 @@ public class SkyTorrentsAdapter extends RssFeedSearchAdapter {
     return false;
   }
 
-  @Override
-  public boolean usesToken() {
-    return false;
+  public AuthType getAuthType() {
+    return AuthType.USERNAME;
+  }
+
+  public String[] getRequiredCookies() {
+    return null;
   }
 
 }

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/SkyTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/SkyTorrentsAdapter.java
@@ -161,13 +161,8 @@ public class SkyTorrentsAdapter extends RssFeedSearchAdapter {
     return "Sky Torrents";
   }
 
-  @Override
-  public boolean isPrivateSite() {
-    return false;
-  }
-
   public AuthType getAuthType() {
-    return AuthType.USERNAME;
+    return AuthType.NONE;
   }
 
   public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentDownloadsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentDownloadsAdapter.java
@@ -29,22 +29,22 @@ import org.transdroid.util.FileSizeConverter;
 
 /**
  * Search adapter for the Torrent Downloads torrent site (based on custom search RSS feeds)
- * 
+ *
  * @author Eric Kok
  */
 public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
-	
+
 	protected SearchResult fromRssItemToSearchResult(Item item) {
 		// Direct .torrent file download in style http://www.torrentdownloads.me/torrent/<id>/<title>
 		// Web links (as appearing in the RSS item) in style http://www.torrentdownloads.me/download/<id>/<title>
 		TorrentDownloadsItem theItem = (TorrentDownloadsItem) item;
 		return new SearchResult(
-				item.getTitle(), 
+				item.getTitle(),
 				"http://www.torrentdownloads.me" + item.getLink().replace("/torrent/", "/download/"),
 				"http://www.torrentdownloads.me" + item.getLink(),
-				FileSizeConverter.getSize(theItem.getSize()),  
+				FileSizeConverter.getSize(theItem.getSize()),
 				item.getPubdate(),
-				theItem.getSeeders(), 
+				theItem.getSeeders(),
 				theItem.getLeechers());
 	}
 
@@ -63,7 +63,7 @@ public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
 	protected RssParser getRssParser(String url) {
 		return new TorrentDownloadsRssParser(url);
 	}
-	
+
 	/**
 	 * Custom Item with addition size, seeders and leechers data properties
 	 */
@@ -78,7 +78,7 @@ public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
 		public int getSeeders() { return seeders; }
 		public int getLeechers() { return leechers; }
 	}
-	
+
 	/**
 	 * Custom parser to parse the additional size, seeders and leechers data properties
 	 */
@@ -87,7 +87,7 @@ public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
 		public TorrentDownloadsRssParser(String url) {
 			super(url);
 		}
-		
+
 		public Item createNewItem() {
 			return new TorrentDownloadsItem();
 		}
@@ -116,9 +116,12 @@ public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentDownloadsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentDownloadsAdapter.java
@@ -111,13 +111,8 @@ public class TorrentDownloadsAdapter extends RssFeedSearchAdapter {
 		return "Torrent Downloads";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentReactorAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentReactorAdapter.java
@@ -71,13 +71,8 @@ public class TorrentReactorAdapter extends RssFeedSearchAdapter {
 		return "TorrentReactor";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentReactorAdapter.java
+++ b/app/src/main/java/org/transdroid/search/RssFeedSearch/TorrentReactorAdapter.java
@@ -27,9 +27,9 @@ import org.transdroid.search.SortOrder;
 
 /**
  * Search adapter for the Torrentreactor.net torrent site (based on custom search RSS feeds).
- * 
+ *
  * NOTE: Currently doesn't provides a direct .torrent link, so it is disabled.
- * 
+ *
  * @author Eric Kok
  */
 public class TorrentReactorAdapter extends RssFeedSearchAdapter {
@@ -44,11 +44,11 @@ public class TorrentReactorAdapter extends RssFeedSearchAdapter {
 		int seeders = Integer.parseInt(d.substring(statusStart, d.indexOf(" ", statusStart)));
 		int leechersStart = d.indexOf("seeder, ", statusStart) + "seeder, ".length();
 		int leechers = Integer.parseInt(d.substring(leechersStart, d.indexOf(" ", leechersStart)));
-		
+
 		return new SearchResult(
-				item.getTitle(), 
-				item.getEnclosureUrl(), 
-				item.getLink(),  
+				item.getTitle(),
+				item.getEnclosureUrl(),
+				item.getLink(),
 				size,
 				item.getPubdate(),
 				seeders,
@@ -76,9 +76,12 @@ public class TorrentReactorAdapter extends RssFeedSearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/ScambioEtico/ScambioEtico.java
+++ b/app/src/main/java/org/transdroid/search/ScambioEtico/ScambioEtico.java
@@ -239,12 +239,6 @@ public class ScambioEtico implements ISearchAdapter {
 		return "Scambio Etico";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		// Not really private, still it requires registration.
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/ScambioEtico/ScambioEtico.java
+++ b/app/src/main/java/org/transdroid/search/ScambioEtico/ScambioEtico.java
@@ -67,17 +67,17 @@ public class ScambioEtico implements ISearchAdapter {
 	private static final String SORT_SEEDS = "&sb=4";
 	private static final int CONNECTION_TIMEOUT = 8000;
 	private static final String ENCODING = "ISO-8859-1";
-	
+
 	private static final String WRONG_PASSWORD = "Password errata. Inserisci la password rispettando "
 			+ "i caratteri MAIUSCOLI e minuscoli.";
 	private static final String WRONG_LOGIN = "Non &#232; possibile trovare un utente del Forum "
 			+ "chiamato <b>";
-	
+
 	// Texts to find subsequently (Used in parseHtml)
 	private static final String START_RESULTS = "<!--TORRENT TABLE-->";
 	private static final String END_RESULTS = "<!--END TORRENT TABLE-->";
 	private static final String ITEM_PREFIX = "<tr class=\"row4\">";
-	
+
 	// Regexps for extracting the informations that we care (Used in parseHtmlItem)
 	private static final String MAIN_EXTRACTOR =
 			"<a [^>]*href='(http://forum.tntvillage.scambioetico.org/"
@@ -90,7 +90,7 @@ public class ScambioEtico implements ISearchAdapter {
 	private static final String SEEDS_EXTRACTOR =
 			"\\[<span [^>]*style='color:red'[^>]*>[^0-9\\.>]*([0-9]+)[^0-9\\.>]*</span>\\]";
 	private static final String LEECHERS_EXTRACTOR =
-			"\\[<span [^>]*style='color:green'[^>]*>[^0-9\\.>]*([0-9]+)[^0-9\\.>]*</span>\\]";	
+			"\\[<span [^>]*style='color:green'[^>]*>[^0-9\\.>]*([0-9]+)[^0-9\\.>]*</span>\\]";
 
 	private DefaultHttpClient prepareRequest(SharedPreferences prefs) throws Exception {
 
@@ -171,7 +171,7 @@ public class ScambioEtico implements ISearchAdapter {
 	protected List<SearchResult> parseHtml(String html, int maxResults) throws Exception {
 		int startResults = html.indexOf(START_RESULTS);
 		int endResults = html.indexOf(END_RESULTS);
-		
+
 		List<SearchResult> results = new ArrayList<SearchResult>();
 
 		if (startResults < 0) {
@@ -183,7 +183,7 @@ public class ScambioEtico implements ISearchAdapter {
 			// pragmatic approach... and parsing html without a clear interface is fragile anyway.
 			endResults = html.length();
 		}
-		
+
 		startResults += START_RESULTS.length();
 		String resultsTable = html.substring(startResults, endResults);
 
@@ -192,9 +192,9 @@ public class ScambioEtico implements ISearchAdapter {
 			itemsPointer += ITEM_PREFIX.length();
 			int nextItem = resultsTable.indexOf(ITEM_PREFIX, itemsPointer);
 			nextItem = (nextItem >= 0) ? nextItem : resultsTable.length();
-			
+
 			results.add(parseHtmlItem(resultsTable.substring(itemsPointer, nextItem)));
-			
+
 			itemsPointer = nextItem;
 		} while (itemsPointer < resultsTable.length() && results.size() < maxResults);
 		return results;
@@ -203,7 +203,7 @@ public class ScambioEtico implements ISearchAdapter {
 	private String extractData(String regexp, String htmlItem) {
 		return extractData(regexp, htmlItem, 1);
 	}
-	
+
 	private String extractData(String regexp, String htmlItem, int group) {
 		Pattern pattern = Pattern.compile(regexp);
 		Matcher matcher = pattern.matcher(htmlItem);
@@ -211,10 +211,10 @@ public class ScambioEtico implements ISearchAdapter {
 			throw new IllegalStateException(
 					"Impossible to parse results. Probably Scambio Etico refactored its html and this application must be updated.");
 		}
-		
+
 		return matcher.group(group);
 	}
-	
+
 	private SearchResult parseHtmlItem(String htmlItem) throws UnsupportedEncodingException {
 		String title = Html.fromHtml(extractData(MAIN_EXTRACTOR, htmlItem, 2)).toString();
 		String detailsUrl = Html.fromHtml(extractData(MAIN_EXTRACTOR, htmlItem, 1)).toString();
@@ -222,8 +222,8 @@ public class ScambioEtico implements ISearchAdapter {
 		String size = extractData(SIZE_EXTRACTOR, htmlItem) + " GiB";
 		int seeds = Integer.parseInt(extractData(SEEDS_EXTRACTOR, htmlItem));
 		int leechers = Integer.parseInt(extractData(LEECHERS_EXTRACTOR, htmlItem));
-		
-		
+
+
 		return new SearchResult(title, String.format(TORRENT_URL, torrentId), detailsUrl, size, null, seeds, leechers);
 
 	}
@@ -245,9 +245,12 @@ public class ScambioEtico implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/ThePirateBay/ThePirateBayAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ThePirateBay/ThePirateBayAdapter.java
@@ -201,9 +201,12 @@ public class ThePirateBayAdapter implements ISearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/ThePirateBay/ThePirateBayAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ThePirateBay/ThePirateBayAdapter.java
@@ -196,13 +196,8 @@ public class ThePirateBayAdapter implements ISearchAdapter {
 		return new SearchResult(name, magnetLink, details, size, date, seeders, leechers);
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/TorrentDay/TorrentDayAdapter.java
+++ b/app/src/main/java/org/transdroid/search/TorrentDay/TorrentDayAdapter.java
@@ -1,0 +1,84 @@
+package org.transdroid.search.TorrentDay;
+
+import android.content.SharedPreferences;
+
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.transdroid.search.ISearchAdapter;
+import org.transdroid.search.SearchResult;
+import org.transdroid.search.SortOrder;
+import org.transdroid.search.TorrentSite;
+import org.transdroid.search.gui.SettingsHelper;
+
+public class TorrentDayAdapter implements ISearchAdapter {
+  private static final String QUERY_URL = "https://www.torrentday.com/browse.php?search=%1$s";
+
+  public static void main(String[] args) throws Exception {
+    new TorrentDayAdapter().search(null, "ufc", null, 10);
+  }
+
+  @Override
+  public List<SearchResult> search(SharedPreferences prefs, String query, SortOrder order, int maxResults) throws Exception {
+    final String encodedQuery = URLEncoder.encode(query, "UTF-8");
+    final String url = String.format(QUERY_URL, encodedQuery);
+
+    final String uid = SettingsHelper.getSiteCookie(prefs, TorrentSite.TorrentDay, "uid");
+    String pass = SettingsHelper.getSiteCookie(prefs, TorrentSite.TorrentDay, "pass");
+
+    final Document doc = Jsoup.connect(url)
+        .cookie("uid", uid)
+        .cookie("pass", pass)
+        .get();
+
+    final ArrayList<SearchResult> results = new ArrayList<>();
+    for (Element element : doc.select("tr.browse")) {
+      final Elements torrentNameElement = element.select("a.torrentName");
+      final String title = torrentNameElement.text();
+      final String torrentUrl = element.select("td.dlLinksInfo > a").attr("href");
+      final String detailsUrl = torrentNameElement.attr("href");
+      final String size = element.select("td.sizeInfo").text();
+      final int seeds = Integer.valueOf(element.select("td.seedersInfo").text());
+      final int leechers = Integer.valueOf(element.select("td.leechersInfo").text());
+      results.add(new SearchResult(title, torrentUrl, detailsUrl, size, null, seeds, leechers));
+      if (results.size() == maxResults) {
+        break;
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public String buildRssFeedUrlFromSearch(String query, SortOrder order) {
+    return null;
+  }
+
+  @Override
+  public String getSiteName() {
+    return "TorrentDay";
+  }
+
+  @Override
+  public boolean isPrivateSite() {
+    return true;
+  }
+
+  public AuthType getAuthType() {
+    return AuthType.COOKIES;
+  }
+
+  public String[] getRequiredCookies() {
+    return new String[]{"uid", "pass"};
+  }
+
+  @Override
+  public InputStream getTorrentFile(SharedPreferences prefs, String url) throws Exception {
+    return null;
+  }
+}

--- a/app/src/main/java/org/transdroid/search/TorrentDay/TorrentDayAdapter.java
+++ b/app/src/main/java/org/transdroid/search/TorrentDay/TorrentDayAdapter.java
@@ -64,11 +64,6 @@ public class TorrentDayAdapter implements ISearchAdapter {
     return "TorrentDay";
   }
 
-  @Override
-  public boolean isPrivateSite() {
-    return true;
-  }
-
   public AuthType getAuthType() {
     return AuthType.COOKIES;
   }

--- a/app/src/main/java/org/transdroid/search/TorrentLeech/TorrentLeechAdapter.java
+++ b/app/src/main/java/org/transdroid/search/TorrentLeech/TorrentLeechAdapter.java
@@ -230,9 +230,12 @@ public class TorrentLeechAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/TorrentLeech/TorrentLeechAdapter.java
+++ b/app/src/main/java/org/transdroid/search/TorrentLeech/TorrentLeechAdapter.java
@@ -225,11 +225,6 @@ public class TorrentLeechAdapter implements ISearchAdapter {
 		return "TorrentLeech";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/java/org/transdroid/search/TorrentSite.java
+++ b/app/src/main/java/org/transdroid/search/TorrentSite.java
@@ -33,6 +33,7 @@ import org.transdroid.search.RssFeedSearch.SkyTorrentsAdapter;
 import org.transdroid.search.RssFeedSearch.TorrentDownloadsAdapter;
 import org.transdroid.search.ScambioEtico.ScambioEtico;
 import org.transdroid.search.ThePirateBay.ThePirateBayAdapter;
+import org.transdroid.search.TorrentDay.TorrentDayAdapter;
 import org.transdroid.search.TorrentLeech.TorrentLeechAdapter;
 import org.transdroid.search.hdbitsorg.HdBitsOrgAdapter;
 import org.transdroid.search.hdtorrents.HdTorrentsAdapter;
@@ -148,6 +149,12 @@ public enum TorrentSite {
 		@Override
 		public ISearchAdapter getAdapter() {
 			return new SkyTorrentsAdapter();
+		}
+	},
+	TorrentDay {
+		@Override
+		public ISearchAdapter getAdapter() {
+			return new TorrentDayAdapter();
 		}
 	},
 	TorrentDownloads {

--- a/app/src/main/java/org/transdroid/search/TorrentSitesProvider.java
+++ b/app/src/main/java/org/transdroid/search/TorrentSitesProvider.java
@@ -29,6 +29,8 @@ import android.util.Log;
 
 import org.transdroid.search.gui.SettingsHelper;
 
+import static org.transdroid.search.ISearchAdapter.AuthType.NONE;
+
 /**
  * Provider of a list of available torrent sites.
  * 
@@ -110,7 +112,7 @@ public class TorrentSitesProvider extends ContentProvider {
 			values[1] = site.toString();
 			values[2] = site.getAdapter().getSiteName();
 			values[3] = site.getAdapter().buildRssFeedUrlFromSearch("%s", SortOrder.BySeeders);
-			values[4] = (site.getAdapter().isPrivateSite()? 1: 0);
+			values[4] = (site.getAdapter().getAuthType() != NONE? 1: 0);
 			curs.addRow(values);
 			
 		}

--- a/app/src/main/java/org/transdroid/search/YTS/YtsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/YTS/YtsAdapter.java
@@ -134,9 +134,12 @@ public class YtsAdapter implements ISearchAdapter {
         return false;
     }
 
-    @Override
-    public boolean usesToken() {
-        return false;
+    public AuthType getAuthType() {
+        return AuthType.USERNAME;
+    }
+
+    public String[] getRequiredCookies() {
+        return null;
     }
 
     @Override

--- a/app/src/main/java/org/transdroid/search/YTS/YtsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/YTS/YtsAdapter.java
@@ -129,13 +129,8 @@ public class YtsAdapter implements ISearchAdapter {
         return "YTS (proxied)";
     }
 
-    @Override
-    public boolean isPrivateSite() {
-        return false;
-    }
-
     public AuthType getAuthType() {
-        return AuthType.USERNAME;
+        return AuthType.NONE;
     }
 
     public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/gui/SettingsActivityCompat.java
+++ b/app/src/main/java/org/transdroid/search/gui/SettingsActivityCompat.java
@@ -25,6 +25,8 @@ import android.preference.PreferenceCategory;
 import org.transdroid.search.R;
 import org.transdroid.search.TorrentSite;
 
+import static org.transdroid.search.ISearchAdapter.AuthType.NONE;
+
 /**
  * Backwards-compatible (pre-Honeycomb) version of the activity that shows all public and private torrent sites supported and which allows to enter
  * settings for each site (if appropriate) as well as to enable/disable a site.
@@ -48,7 +50,7 @@ public class SettingsActivityCompat extends PreferenceActivity {
 		PreferenceCategory publicGroup = (PreferenceCategory) findPreference("header_publicsites");
 		PreferenceCategory privateGroup = (PreferenceCategory) findPreference("header_privatesites");
 		for (TorrentSite torrentSite : sites) {
-			if (torrentSite.getAdapter().isPrivateSite()) {
+			if (torrentSite.getAdapter().getAuthType() != NONE) {
 				privateGroup.addPreference(new PrivateSitePreference(this, privateCounter++, torrentSite));
 			} else {
 				publicGroup.addPreference(new PublicSitePreference(this, publicCounter++, torrentSite));

--- a/app/src/main/java/org/transdroid/search/gui/SettingsActivityModern.java
+++ b/app/src/main/java/org/transdroid/search/gui/SettingsActivityModern.java
@@ -28,6 +28,8 @@ import android.preference.PreferenceFragment;
 import org.transdroid.search.R;
 import org.transdroid.search.TorrentSite;
 
+import static org.transdroid.search.ISearchAdapter.AuthType.NONE;
+
 /**
  * The modern-device version (Android 3.0 and later) of the activity that shows all public and private torrent sites supported and which allows to
  * enter settings for each site (if appropriate) as well as to enable/disable a site.
@@ -63,7 +65,7 @@ public class SettingsActivityModern extends Activity {
 			PreferenceCategory publicGroup = (PreferenceCategory) findPreference("header_publicsites");
 			PreferenceCategory privateGroup = (PreferenceCategory) findPreference("header_privatesites");
 			for (TorrentSite torrentSite : sites) {
-				if (torrentSite.getAdapter().isPrivateSite()) {
+				if (torrentSite.getAdapter().getAuthType() != NONE) {
 					privateGroup.addPreference(new PrivateSitePreference(getActivity(), privateCounter++, torrentSite));
 				} else {
 					publicGroup.addPreference(new PublicSitePreference(getActivity(), publicCounter++, torrentSite));

--- a/app/src/main/java/org/transdroid/search/gui/SettingsHelper.java
+++ b/app/src/main/java/org/transdroid/search/gui/SettingsHelper.java
@@ -49,16 +49,9 @@ public class SettingsHelper {
 	 *         otherwise
 	 */
 	public static boolean isSiteEnabled(SharedPreferences prefs, TorrentSite site) {
-
-		// For public sites use the PREF_SITE_ENABLED-based preference only
-		if (!site.getAdapter().isPrivateSite())
-			return prefs.getBoolean(PREF_SITE_ENABLED + site.name(), true);
-
-		// For private sites see if a token or username and password are specified as well
-		if (!prefs.getBoolean(PREF_SITE_ENABLED + site.name(), true))
-			return false;
-
 		switch (site.getAdapter().getAuthType()) {
+			case NONE:
+				return prefs.getBoolean(PREF_SITE_ENABLED + site.name(), false);
 			case TOKEN:
 				return prefs.getString(PREF_SITE_TOKEN + site.name(), null) != null;
 			case USERNAME:

--- a/app/src/main/java/org/transdroid/search/hdbitsorg/HdBitsOrgAdapter.java
+++ b/app/src/main/java/org/transdroid/search/hdbitsorg/HdBitsOrgAdapter.java
@@ -91,11 +91,6 @@ public class HdBitsOrgAdapter implements ISearchAdapter {
         return "hdbits.org";
     }
 
-    @Override
-    public boolean isPrivateSite() {
-        return true;
-    }
-
     public AuthType getAuthType() {
         return AuthType.USERNAME;
     }

--- a/app/src/main/java/org/transdroid/search/hdtorrents/HdTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/hdtorrents/HdTorrentsAdapter.java
@@ -76,7 +76,7 @@ public class HdTorrentsAdapter implements ISearchAdapter {
     private static final String PEER_END_STRING = "</b>";
     private static final String IMDB_START_STRING = "http://www.imdb.com/";
     private static final String IMDB_END_STRING = "\"";
-    
+
     private static final String URL_PREFIX = "https://hd-torrents.org/";
     private static final int CONNECTION_TIMEOUT = 8000;
 
@@ -94,14 +94,17 @@ public class HdTorrentsAdapter implements ISearchAdapter {
         return true;
     }
 
-    @Override
-    public boolean usesToken() {
-        return false;
+    public AuthType getAuthType() {
+        return AuthType.USERNAME;
+    }
+
+    public String[] getRequiredCookies() {
+        return null;
     }
 
     @Override
     public List<SearchResult> search(SharedPreferences prefs, String query, SortOrder order, int maxResults) throws Exception {
-        
+
         DefaultHttpClient client = prepareRequest(prefs);
 
         // build search query
@@ -151,7 +154,7 @@ public class HdTorrentsAdapter implements ISearchAdapter {
             throw new InvalidParameterException(
                     "No username or password was provided, while this is required for this private site.");
         }
-        
+
         // setup our http client
         HttpParams params = new BasicHttpParams();
         HttpConnectionParams.setConnectionTimeout(params, CONNECTION_TIMEOUT);
@@ -186,14 +189,14 @@ public class HdTorrentsAdapter implements ISearchAdapter {
             if ("pass".equals(cookie.getName())) pass = true;
             if ("hashx".equals(cookie.getName())) hash = true;
         }
-        
+
         // if we don't have the correct cookies, login failed. notify user with a toast and toss an exception.
         success = uid && pass && hash;
         if (!success) {
         	Log.e(LOG_TAG, "Failed to log into HD-Torrents as '" + username + "'. Did not receive expected login cookies!");
             throw new LoginException("Failed to log into HD-Torrents as '" + username + "'. Did not receive expected login cookies!");
         }
-        
+
         Log.d(LOG_TAG, "Successfully logged in to HD-Torrents");
     }
 
@@ -278,7 +281,7 @@ public class HdTorrentsAdapter implements ISearchAdapter {
                 resultStart = nextResultStart;
             }
         }
-        
+
         return results;
     }
 }

--- a/app/src/main/java/org/transdroid/search/hdtorrents/HdTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/hdtorrents/HdTorrentsAdapter.java
@@ -89,11 +89,6 @@ public class HdTorrentsAdapter implements ISearchAdapter {
         return "HD-Torrents";
     }
 
-    @Override
-    public boolean isPrivateSite() {
-        return true;
-    }
-
     public AuthType getAuthType() {
         return AuthType.USERNAME;
     }

--- a/app/src/main/java/org/transdroid/search/ncore/NcoreAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ncore/NcoreAdapter.java
@@ -216,11 +216,6 @@ public class NcoreAdapter implements ISearchAdapter {
         return "Ncore";
     }
 
-    @Override
-    public boolean isPrivateSite() {
-        return true;
-    }
-
     public AuthType getAuthType() {
         return AuthType.USERNAME;
     }

--- a/app/src/main/java/org/transdroid/search/ncore/NcoreAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ncore/NcoreAdapter.java
@@ -126,7 +126,7 @@ public class NcoreAdapter implements ISearchAdapter {
         int torStart = html.indexOf(TORRENT, resultsStart);
         while (torStart >= 0 && results.size() < maxResults) {
             int nextTorrentIndex = html.indexOf(TORRENT, torStart + TORRENT.length());
-            int endTorrentIndex  = html.indexOf(TORRENT_END, torStart);
+            int endTorrentIndex = html.indexOf(TORRENT_END, torStart);
             if (nextTorrentIndex >= 0) {
                 results.add(parseHtmlItem(html.substring(torStart + TORRENT.length(), endTorrentIndex)));
             } else {
@@ -221,9 +221,12 @@ public class NcoreAdapter implements ISearchAdapter {
         return true;
     }
 
-    @Override
-    public boolean usesToken() {
-        return false;
+    public AuthType getAuthType() {
+        return AuthType.USERNAME;
+    }
+
+    public String[] getRequiredCookies() {
+        return null;
     }
 
 }

--- a/app/src/main/java/org/transdroid/search/rarbg/RarbgAdapter.java
+++ b/app/src/main/java/org/transdroid/search/rarbg/RarbgAdapter.java
@@ -47,9 +47,12 @@ public class RarbgAdapter implements ISearchAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 	@Override

--- a/app/src/main/java/org/transdroid/search/rarbg/RarbgAdapter.java
+++ b/app/src/main/java/org/transdroid/search/rarbg/RarbgAdapter.java
@@ -42,13 +42,8 @@ public class RarbgAdapter implements ISearchAdapter {
 		return "RARBG";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return false;
-	}
-
 	public AuthType getAuthType() {
-		return AuthType.USERNAME;
+		return AuthType.NONE;
 	}
 
 	public String[] getRequiredCookies() {

--- a/app/src/main/java/org/transdroid/search/revolutiontt/RevolutionTTAdapter.java
+++ b/app/src/main/java/org/transdroid/search/revolutiontt/RevolutionTTAdapter.java
@@ -228,9 +228,12 @@ public class RevolutionTTAdapter implements ISearchAdapter {
 		return true;
 	}
 
-	@Override
-	public boolean usesToken() {
-		return false;
+	public AuthType getAuthType() {
+		return AuthType.USERNAME;
+	}
+
+	public String[] getRequiredCookies() {
+		return null;
 	}
 
 }

--- a/app/src/main/java/org/transdroid/search/revolutiontt/RevolutionTTAdapter.java
+++ b/app/src/main/java/org/transdroid/search/revolutiontt/RevolutionTTAdapter.java
@@ -223,11 +223,6 @@ public class RevolutionTTAdapter implements ISearchAdapter {
 		return "RevolutionTT";
 	}
 
-	@Override
-	public boolean isPrivateSite() {
-		return true;
-	}
-
 	public AuthType getAuthType() {
 		return AuthType.USERNAME;
 	}

--- a/app/src/main/res/layout/dialog_cookies.xml
+++ b/app/src/main/res/layout/dialog_cookies.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_cookies_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="20dp" >
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="pref_publicsites">Public sites</string>
     <string name="pref_privatesites">Private sites</string>
     <string name="pref_credentials">Site credentials</string>
+    <string name="pref_cookies">Site cookies</string>
     <string name="pref_token">Site token</string>
     <string name="pref_hint_username">Username</string>
     <string name="pref_hint_password">Password</string>


### PR DESCRIPTION
I wanted to add TorrentDay, a  private site I use.

TD uses a Capcha a so it's hard to login from code. I considered using an RSS adapter but TD has a feed per category and and creating a feed for all categories would result in a very small result set per category.

I noticed that TD uses a simple Cookie based authentication system so it's possible to extract the cookies from an authenticated HTTP request and add to a request in the app.

So I added a new auth type. Since now there are 3 types (Username, Token & Cookies), I changed usesToken() and isPrivate() to a single getAuthType() that returns one of the 3 types or NONE for public sites.

I also added a new dependency (JSoup) for parsing HTML. It makes parsing trivial and I think it would be nice to someday migrate all adapters to use it.
