### PR TITLE
Added IPTorrents private torrent site

### DIFF
--- a/app/src/main/java/org/transdroid/search/ISearchAdapter.java
+++ b/app/src/main/java/org/transdroid/search/ISearchAdapter.java
@@ -90,6 +90,7 @@ public interface ISearchAdapter {
     enum AuthType {
         NONE,
         TOKEN,
+        TOKEN_AND_UID,
         USERNAME,
         COOKIES,
         CUSTOM

--- a/app/src/main/java/org/transdroid/search/TorrentSite.java
+++ b/app/src/main/java/org/transdroid/search/TorrentSite.java
@@ -34,6 +34,7 @@ import org.transdroid.search.adapters.privatetrackers.RevolutionTTAdapter;
 import org.transdroid.search.adapters.privatetrackers.TorrentLeechAdapter;
 import org.transdroid.search.adapters.publictrackers.RarbgAdapter;
 import org.transdroid.search.adapters.publictrackers.YtsAdapter;
+import org.transdroid.search.adapters.rss.privatetrackers.IPTorrentsAdapter;
 import org.transdroid.search.adapters.rss.privatetrackers.PretomeAdapter;
 import org.transdroid.search.adapters.rss.publictrackers.LimeTorrentsAdapter;
 import org.transdroid.search.adapters.rss.publictrackers.NyaaTorrentsAdapter;
@@ -155,6 +156,10 @@ public enum TorrentSite {
         public ISearchAdapter getAdapter() {
             return new YtsAdapter();
         }
+    },
+    IPTorrents {
+        @Override
+        public ISearchAdapter getAdapter() { return new IPTorrentsAdapter(); }
     };
 
     /**

--- a/app/src/main/java/org/transdroid/search/adapters/custom/CustomSiteAdapter.java
+++ b/app/src/main/java/org/transdroid/search/adapters/custom/CustomSiteAdapter.java
@@ -79,7 +79,7 @@ public class CustomSiteAdapter extends RssFeedSearchAdapter {
         CustomSiteItem theItem = (CustomSiteItem) item;
         return new SearchResult(
                 item.getTitle(),
-                item.getEnclosureUrl(),
+                item.getTheLink(),
                 theItem.detailsLink,
                 FileSizeConverter.getSize(theItem.size),
                 item.getPubdate(),

--- a/app/src/main/java/org/transdroid/search/adapters/rss/privatetrackers/IPTorrentsAdapter.java
+++ b/app/src/main/java/org/transdroid/search/adapters/rss/privatetrackers/IPTorrentsAdapter.java
@@ -1,0 +1,130 @@
+/*
+ *	This file is part of Transdroid Torrent Search
+ *	<http://code.google.com/p/transdroid-search/>
+ *
+ *	Transdroid Torrent Search is free software: you can redistribute
+ *	it and/or modify it under the terms of the GNU Lesser General
+ *	Public License as published by the Free Software Foundation,
+ *	either version 3 of the License, or (at your option) any later
+ *	version.
+ *
+ *	Transdroid Torrent Search is distributed in the hope that it will
+ *	be useful, but WITHOUT ANY WARRANTY; without even the implied
+ *	warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *	See the GNU Lesser General Public License for more details.
+ *
+ *	You should have received a copy of the GNU Lesser General Public
+ *	License along with Transdroid.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.transdroid.search.adapters.rss.privatetrackers;
+
+import android.content.SharedPreferences;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.ifies.android.sax.Item;
+import org.ifies.android.sax.RssParser;
+import org.transdroid.search.SearchResult;
+import org.transdroid.search.SortOrder;
+import org.transdroid.search.TorrentSite;
+import org.transdroid.search.adapters.rss.RssFeedSearchAdapter;
+import org.transdroid.search.gui.SettingsHelper;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.security.InvalidParameterException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+/**
+ * Search adapter for the Pretome private torrent site (based on custom search RSS feeds). Requires user to enter their RSS feed token.
+ *
+ * @author Eric Kok
+ */
+public class IPTorrentsAdapter extends RssFeedSearchAdapter {
+
+    // String.format(FORMATTED_URI, uid, token, query);
+    private static String FORMATTED_URI = "https://iptorrents.com/t.rss?u=%s;tp=%s;48;20;100;101;68;22;99;5;65;download;q=%s";
+
+    // Fri, 20 Aug 2021 21:59:14 +0000
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);
+
+    private SharedPreferences prefs;
+
+    @Override
+    public List<SearchResult> search(SharedPreferences prefs, String query, SortOrder order, int maxResults) throws Exception {
+        this.prefs = prefs;
+        return super.search(prefs, query, order, maxResults);
+    }
+
+    @Override
+    public String buildRssFeedUrlFromSearch(SharedPreferences prefs, String query, SortOrder order) {
+        this.prefs = prefs;
+        return super.buildRssFeedUrlFromSearch(prefs, query, order);
+    }
+
+    @Override
+    protected String getUrl(String query, SortOrder order) {
+        String token = SettingsHelper.getSiteToken(prefs, TorrentSite.IPTorrents);
+        String uid = SettingsHelper.getSiteUserId(prefs, TorrentSite.IPTorrents);
+        if (token == null || uid == null) {
+            throw new InvalidParameterException("RSS feed token and user id is required for IPTorrents.");
+        }
+
+        try {
+            return String.format(Locale.US, FORMATTED_URI, uid, token, URLEncoder.encode(query, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected SearchResult fromRssItemToSearchResult(Item item) {
+
+        /*
+         *   <item>
+         *   <title>full title</title>
+         *   <link>https://...</link>
+         *   <pubDate>Fri, 20 Aug 2021 21:59:14 +0000</pubDate>
+         *   <description>291 MB; TV/x265</description>
+         *   </item>
+         */
+        return new SearchResult(
+                item.getTitle(),
+                item.getLink(),
+                item.getLink(),
+                item.getDescription(),
+                item.getPubdate(),
+                0,
+                0);
+    }
+
+    @Override
+    public String getSiteName() {
+        return "IPTorrents";
+    }
+
+    public AuthType getAuthType() {
+        return AuthType.TOKEN_AND_UID;
+    }
+
+    @Override
+    protected RssParser getRssParser(final String url) {
+        return new RssParser(url);
+    }
+
+}

--- a/app/src/main/java/org/transdroid/search/gui/PrivateSitePreference.java
+++ b/app/src/main/java/org/transdroid/search/gui/PrivateSitePreference.java
@@ -51,7 +51,7 @@ public class PrivateSitePreference extends DialogPreference {
 
     private final Pair<String, ISearchAdapter> torrentSite;
     private final AuthType authType;
-    private EditText userEdit, passEdit, tokenEdit;
+    private EditText userEdit, passEdit, tokenEdit, uidEdit;
     private Map<String, EditText> cookieEdits;
 
     PrivateSitePreference(Context context, int sortOrder, Pair<String, ISearchAdapter> torrentSite) {
@@ -65,6 +65,10 @@ public class PrivateSitePreference extends DialogPreference {
         switch (authType) {
             case TOKEN:
                 setDialogLayoutResource(R.layout.dialog_token);
+                setDialogTitle(R.string.pref_token);
+                break;
+            case TOKEN_AND_UID:
+                setDialogLayoutResource(R.layout.dialog_token_and_uid);
                 setDialogTitle(R.string.pref_token);
                 break;
             case USERNAME:
@@ -112,6 +116,13 @@ public class PrivateSitePreference extends DialogPreference {
                 // Show token for easy modification
                 tokenEdit.setText(prefs.getString(SettingsHelper.PREF_SITE_TOKEN + torrentSite.first, ""));
                 break;
+            case TOKEN_AND_UID:
+                tokenEdit = dialog.findViewById(R.id.token);
+                uidEdit = dialog.findViewById(R.id.uid);
+                // Show token and uid for easy modification
+                tokenEdit.setText(prefs.getString(SettingsHelper.PREF_SITE_TOKEN + torrentSite.first, ""));
+                uidEdit.setText(prefs.getString(SettingsHelper.PREF_SITE_USER_ID + torrentSite.first, ""));
+                break;
             case USERNAME:
                 userEdit = dialog.findViewById(R.id.username);
                 passEdit = dialog.findViewById(R.id.password);
@@ -141,6 +152,10 @@ public class PrivateSitePreference extends DialogPreference {
                 case TOKEN:
                     persistToken();
                     break;
+                case TOKEN_AND_UID:
+                    persistToken();
+                    persistUserId();
+                    break;
                 case USERNAME:
                     persistUserAndPass();
                     break;
@@ -157,6 +172,15 @@ public class PrivateSitePreference extends DialogPreference {
             token = null;
         Editor edit = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
         edit.putString(SettingsHelper.PREF_SITE_TOKEN + torrentSite.first, token);
+        edit.apply();
+    }
+
+    private void persistUserId() {
+        String uid = uidEdit.getText().toString();
+        if (TextUtils.isEmpty(uid))
+            uid = null;
+        Editor edit = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
+        edit.putString(SettingsHelper.PREF_SITE_USER_ID + torrentSite.first, uid);
         edit.apply();
     }
 

--- a/app/src/main/java/org/transdroid/search/gui/SettingsHelper.java
+++ b/app/src/main/java/org/transdroid/search/gui/SettingsHelper.java
@@ -47,6 +47,7 @@ public class SettingsHelper {
     static final String PREF_SITE_COOKIE = "pref_key_cookie_";
     static final String PREF_SITE_CUSTOM_NAME = "pref_key_custom_name_";
     static final String PREF_SITE_CUSTOM_URL = "pref_key_custom_url_";
+    static final String PREF_SITE_USER_ID = "pref_key_user_id_";
     private static final String CODE_PREFIX_CUSTOM = "custom_";
 
     public static ISearchAdapter getSiteByCode(SharedPreferences prefs, String code) {
@@ -89,6 +90,9 @@ public class SettingsHelper {
                 return prefs.getBoolean(PREF_SITE_ENABLED + siteCode, false);
             case TOKEN:
                 return prefs.getString(PREF_SITE_TOKEN + siteCode, null) != null;
+            case TOKEN_AND_UID:
+                return prefs.getString(PREF_SITE_TOKEN + siteCode, null) != null
+                        && prefs.getString(PREF_SITE_USER_ID + siteCode, null) != null;
             case USERNAME:
                 return prefs.getString(PREF_SITE_USER + siteCode, null) != null
                         && prefs.getString(PREF_SITE_PASS + siteCode, null) != null;
@@ -138,6 +142,10 @@ public class SettingsHelper {
      */
     public static String getSiteToken(SharedPreferences prefs, TorrentSite site) {
         return prefs.getString(PREF_SITE_TOKEN + site.name(), null);
+    }
+
+    public static String getSiteUserId(SharedPreferences prefs, TorrentSite site) {
+        return prefs.getString(PREF_SITE_USER_ID + site.name(), null);
     }
 
     public static void setSiteCookie(Editor editor, String siteCode, String name, String value) {

--- a/app/src/main/res/layout/dialog_token_and_uid.xml
+++ b/app/src/main/res/layout/dialog_token_and_uid.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <EditText
+        android:id="@+id/token"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/pref_hint_token" />
+
+    <EditText
+        android:id="@+id/uid"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/pref_hint_uid" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,8 @@
     <string name="pref_token">Site token</string>
     <string name="pref_hint_username">Username</string>
     <string name="pref_hint_password">Password</string>
-    <string name="pref_hint_token">API/session token</string>
+    <string name="pref_hint_token">API Token (passkey)</string>
+    <string name="pref_hint_uid">User ID (not Username)</string>
     <string name="pref_hint_name">(Optional) name</string>
     <string name="pref_hint_url_explanation">Link to the RSS feed, including any access token, where \u0025s will be replaced by the search string, e.g.\nhttps://site.com/torrents?q=\u0025</string>
     <string name="pref_hint_url">URL</string>


### PR DESCRIPTION
IPT's RSS feed requires a passkey (ie **TOKEN**) and a database id for your user (ie **UID** -- NOT Username).
In order to facilitate both requirements in the prefs, I added **AuthType.TOKEN_AND_UID** so we can prompt for both fields.

The **UID** can be found by logging in, opening your profile page, and observing the URL.
Ex:    `https://iptorrents.com/user.php?u=<uid>`
The **TOKEN** is in this page as well, labeled as "passkey" if you scroll down a little.


They are also both present if you generate an RSS feed from the site.
Ex:       `https://iptorrents.com/t.rss?u=<uid>;tp=<token>;....`
